### PR TITLE
Exponential notation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,12 @@ function toJSON(input) {
 			else  
 				return s;
 		})
-		.replace(/(?:true|false|null)(?=[^\w_$]|$)|([a-zA-Z_$][\w_$]*)|`((?:\\.|[^`])*)`|'((?:\\.|[^'])*)'|"(?:\\.|[^"])*"|(,)(?=\s*[}\]])/g, // pass 2: requote
-							 function(s, identifier, multilineQuote, singleQuote, lonelyComma) {
+		.replace(/(?:true|false|null)(?=[^\w_$]|$)|(-?\d+(?:\.?\d+)?(?:e-?\d+)?)|([a-zA-Z_$][\w_$]*)|`((?:\\.|[^`])*)`|'((?:\\.|[^'])*)'|"(?:\\.|[^"])*"|(,)(?=\s*[}\]])/g, // pass 2: requote
+							 function(s, number, identifier, multilineQuote, singleQuote, lonelyComma) {
 			if (lonelyComma)
 				return '';
+			else if (number)
+				return number;
 			else if (identifier != null)
 					return '"' + identifier + '"';
 			else if (multilineQuote != null)

--- a/hanson.js
+++ b/hanson.js
@@ -54,10 +54,12 @@
 			else  
 				return s;
 		})
-		.replace(/(?:true|false|null)(?=[^\w_$]|$)|([a-zA-Z_$][\w_$]*)|`((?:\\.|[^`])*)`|'((?:\\.|[^'])*)'|"(?:\\.|[^"])*"|(,)(?=\s*[}\]])/g, // pass 2: requote 
-							 function(s, identifier, multilineQuote, singleQuote, lonelyComma) {
+		.replace(/(?:true|false|null)(?=[^\w_$]|$)|(-?\d+(?:\.?\d+)?(?:e-?\d+)?)|([a-zA-Z_$][\w_$]*)|`((?:\\.|[^`])*)`|'((?:\\.|[^'])*)'|"(?:\\.|[^"])*"|(,)(?=\s*[}\]])/g, // pass 2: requote
+							 function(s, number, identifier, multilineQuote, singleQuote, lonelyComma) {
 			if (lonelyComma)
 				return '';
+			else if (number)
+				return number;
 			else if (identifier != null)
 					return '"' + identifier + '"';
 			else if (multilineQuote != null)


### PR DESCRIPTION
Current implementation of toJSON incorrectly handles exponential notation (`1.3e-12` becomes `1.3"e"-12`). I've added another capture group to "requote" regex so that it will leave numbers in exponential notation alone. Example: https://jsbin.com/fujajayewu/3/edit?js,console